### PR TITLE
refactor: 改用 nginx.org 官方主线包替代源码编译

### DIFF
--- a/0.nginx/README.md
+++ b/0.nginx/README.md
@@ -1,8 +1,8 @@
-# Nginx 1.28.1 部署指南（支持 HTTP/3）
+# Nginx 部署指南（支持 HTTP/3）
 
-> **版本**: v4.0
-> **更新日期**: 2026-01-16
-> **Nginx 版本**: 1.28.1（支持 HTTP/3 QUIC 协议）
+> **版本**: v5.0
+> **更新日期**: 2026-05-27
+> **Nginx 来源**: nginx.org 官方主线仓库（支持 HTTP/3 QUIC 协议）
 > **适用场景**: VPS 集群基础设施部署
 
 ---
@@ -27,10 +27,9 @@
 
 ### 核心功能
 
-- **Nginx 1.28.1 源码编译安装**: 支持最新的 HTTP/3 (QUIC) 协议
+- **Nginx 官方主线包安装**: 来自 nginx.org，支持最新的 HTTP/3 (QUIC) 协议
 - **系统内核优化**: 自动开启 BBR 拥塞控制，优化 TCP 连接参数
-- **模块化配置结构**: 构建 `conf.d` 目录结构，方便后续服务扩展
-- **低内存适配**: 自动为低内存服务器（<1GB）创建 Swap 空间
+- **模块化配置结构**: 使用标准 `/etc/nginx/conf.d` 目录，方便后续服务扩展
 
 ### 技术特性
 
@@ -39,14 +38,13 @@
 | **HTTP/3 (QUIC)** | 基于 UDP 的新一代 HTTP 协议，减少连接延迟 |
 | **HTTP/2** | 多路复用，头部压缩，服务器推送 |
 | **TCP BBR** | Google 拥塞控制算法，提升网络吞吐量 |
-| **Stream 模块** | 支持四层 TCP/UDP 代理（用于负载均衡） |
 | **RealIP 模块** | 支持 Cloudflare 等 CDN 的真实 IP 还原 |
 
 ### 为什么需要先部署此脚本？
 
 ```
                     ┌─────────────────────────────────────────┐
-                    │      0.nginx部署（1.28.1 HTTP3）         │
+                    │      0.nginx部署（HTTP/3）               │
                     │          【基础设施层 - 必须先部署】        │
                     └────────────────────┬────────────────────┘
                                          │
@@ -72,30 +70,30 @@
 
 | 项目 | 最低配置 | 推荐配置 |
 |------|---------|---------|
-| **操作系统** | Ubuntu 20.04 / Debian 11 / CentOS 7 | Ubuntu 22.04+ |
-| **内存** | 512MB | 1GB+ |
-| **磁盘** | 500MB 可用空间 | 2GB+ |
+| **操作系统** | Ubuntu 20.04 / Debian 11 | Ubuntu 22.04+ |
+| **内存** | 256MB | 512MB+ |
+| **磁盘** | 100MB 可用空间 | 500MB+ |
 | **内核版本** | 4.9+（BBR 支持） | 5.4+ |
 | **权限** | root | root |
 
 ### 一键部署
 
 ```bash
-cd "0.nginx部署（1.28.1 HTTP3）"
+cd 0.nginx
 chmod +x install_nginx.sh
 ./install_nginx.sh
 ```
 
-**部署时间**: 约 5-10 分钟（取决于服务器性能和网络速度）
+**部署时间**: 约 30 秒（纯 apt 安装，无需编译）
 
 ### 验证安装
 
 ```bash
 # 检查 Nginx 版本
-/usr/local/nginx/sbin/nginx -V
+nginx -v
 
 # 验证 HTTP/3 模块
-/usr/local/nginx/sbin/nginx -V 2>&1 | grep http_v3
+nginx -V 2>&1 | grep http_v3
 
 # 检查服务状态
 systemctl status nginx
@@ -112,25 +110,20 @@ sysctl net.ipv4.tcp_congestion_control
 ### 脚本执行流程
 
 ```
-[1/4] 系统环境检查与优化
+[1/3] 系统环境检查与优化
       ├─ 检查 Root 权限
-      ├─ 检测内存，低于 1GB 自动创建 Swap
       ├─ 配置内核参数（BBR、TCP 优化）
       └─ 提升文件描述符限制
 
-[2/4] 安装依赖库
-      ├─ Ubuntu/Debian: build-essential, libssl-dev, libpcre3-dev...
-      └─ CentOS/RHEL: Development Tools, openssl-devel...
+[2/3] 安装 Nginx（nginx.org 官方主线包）
+      ├─ 添加 nginx.org GPG 签名密钥
+      ├─ 添加主线仓库源
+      ├─ apt install nginx
+      └─ 自动包含 HTTP/3 支持
 
-[3/4] 编译安装 Nginx 1.28.1
-      ├─ 下载官方源码
-      ├─ 配置编译参数（24+ 模块）
-      ├─ 编译并安装到 /usr/local/nginx
-      └─ 创建目录结构
-
-[4/4] 配置 Nginx 结构
-      ├─ 生成主配置文件（nginx.conf）
-      ├─ 创建 Systemd 服务
+[3/3] 配置 Nginx 高并发优化
+      ├─ 生成 nginx.conf（高并发调优）
+      ├─ 创建 SSL 证书存储目录
       └─ 启动并启用开机自启
 ```
 
@@ -140,14 +133,15 @@ sysctl net.ipv4.tcp_congestion_control
 
 ```
 ==============================================
-   Nginx 安装与系统优化完成 (v4.0)
+   Nginx 安装与系统优化完成 (v5.0)
 ==============================================
-Nginx 版本:   1.28.1 (支持 HTTP/3)
-Nginx 路径:   /usr/local/nginx
-配置文件:     /usr/local/nginx/conf/nginx.conf
-扩展配置:     /usr/local/nginx/conf/conf.d/*.conf
+Nginx 版本:   1.27.x
+安装来源:     nginx.org 官方主线仓库
+配置文件:     /etc/nginx/nginx.conf
+站点配置:     /etc/nginx/conf.d/*.conf
+SSL 证书:     /etc/nginx/ssl/
 优化状态:     BBR 已开启, Limit 已提升
-HTTP/3 支持:  ✓ 已编译 (--with-http_v3_module)
+HTTP/3 支持:  ✓ (内置 --with-http_v3_module)
 ==============================================
 ```
 
@@ -189,64 +183,24 @@ net.core.somaxconn = 32768        # 连接队列大小
 
 支持 Nginx 的 `worker_connections 10240` 配置。
 
-### 自动 Swap 创建
-
-当检测到内存低于 1GB 时，自动创建 1.5GB Swap：
-
-```bash
-# 创建位置
-/swapfile_install
-
-# 自动持久化到 /etc/fstab
-```
-
 ---
 
 ## Nginx 模块说明
 
-### 已编译模块列表
+### 官方包内建模块
 
-| 模块 | 编译参数 | 用途 |
-|------|---------|------|
-| **SSL** | `--with-http_ssl_module` | HTTPS 支持 |
-| **HTTP/2** | `--with-http_v2_module` | HTTP/2 协议 |
-| **HTTP/3** | `--with-http_v3_module` | HTTP/3 QUIC 协议 |
-| **RealIP** | `--with-http_realip_module` | 获取真实客户端 IP（CDN 场景） |
-| **Status** | `--with-http_stub_status_module` | Nginx 状态监控 |
-| **Gzip Static** | `--with-http_gzip_static_module` | 预压缩静态文件 |
-| **Gunzip** | `--with-http_gunzip_module` | 解压缩模块 |
-| **Sub** | `--with-http_sub_module` | 内容替换（伪装） |
-| **FLV** | `--with-http_flv_module` | FLV 流媒体 |
-| **MP4** | `--with-http_mp4_module` | MP4 伪流媒体 |
-| **DAV** | `--with-http_dav_module` | WebDAV 支持 |
-| **Stream** | `--with-stream` | TCP/UDP 四层代理 |
-| **Stream SSL** | `--with-stream_ssl_module` | Stream SSL 支持 |
-| **Stream SSL Preread** | `--with-stream_ssl_preread_module` | SNI 路由 |
-| **Stream RealIP** | `--with-stream_realip_module` | Stream 真实 IP |
+Nginx 官方主线包已内置以下与项目相关的核心模块：
 
-### 关键模块用途
-
-**Stream 模块系列**（用于 TCP/UDP 四层代理）：
-```nginx
-stream {
-    upstream cn2_backends {
-        server 1.2.3.4:443;
-        server 5.6.7.8:443;
-    }
-    server {
-        listen 443;
-        proxy_pass cn2_backends;
-        ssl_preread on;  # 需要 stream_ssl_preread_module
-    }
-}
-```
-
-**RealIP 模块**（Cloudflare 真实 IP 还原）：
-```nginx
-set_real_ip_from 173.245.48.0/20;
-# ... 更多 Cloudflare IP 段
-real_ip_header CF-Connecting-IP;
-```
+| 模块 | 用途 |
+|------|------|
+| **SSL** | HTTPS 支持 |
+| **HTTP/2** | HTTP/2 协议 |
+| **HTTP/3** | HTTP/3 QUIC 协议 |
+| **RealIP** | 获取真实客户端 IP（CDN 场景） |
+| **Status** | Nginx 状态监控 |
+| **Gzip Static** | 预压缩静态文件 |
+| **Gunzip** | 解压缩模块 |
+| **Sub** | 内容替换（伪装） |
 
 ---
 
@@ -274,16 +228,16 @@ systemctl is-enabled nginx
 
 ```bash
 # 测试配置语法
-/usr/local/nginx/sbin/nginx -t
+nginx -t
 
 # 重载配置
-/usr/local/nginx/sbin/nginx -s reload
+systemctl reload nginx
 
 # 查看当前配置
-cat /usr/local/nginx/conf/nginx.conf
+cat /etc/nginx/nginx.conf
 
 # 查看扩展配置
-ls /usr/local/nginx/conf/conf.d/
+ls /etc/nginx/conf.d/
 ```
 
 ### 日志管理
@@ -295,7 +249,7 @@ tail -f /var/log/nginx/access.log
 # 错误日志
 tail -f /var/log/nginx/error.log
 
-# 日志轮转（系统自动）
+# 日志轮转（系统自动，官方包自带 logrotate 配置）
 cat /etc/logrotate.d/nginx
 ```
 
@@ -306,24 +260,19 @@ cat /etc/logrotate.d/nginx
 ### 安装目录
 
 ```
-/usr/local/nginx/
-├── sbin/
-│   └── nginx              # 可执行文件
-├── conf/
-│   ├── nginx.conf         # 主配置文件
-│   ├── mime.types         # MIME 类型
-│   ├── conf.d/            # 【扩展配置目录】- 后续服务配置存放位置
-│   │   ├── api.example.com.conf
-│   │   ├── newapi.example.com.conf
-│   │   └── ...
-│   └── ssl/               # 【SSL 证书目录】
-│       ├── api.example.com/
-│       │   ├── key.pem
-│       │   └── fullchain.pem
-│       └── ...
-├── logs/
-│   └── nginx.pid
-└── html/                  # 默认网站根目录
+/etc/nginx/
+├── nginx.conf             # 主配置文件
+├── mime.types             # MIME 类型
+├── conf.d/                # 【扩展配置目录】- 后续服务配置存放位置
+│   ├── api.example.com.conf
+│   ├── newapi.example.com.conf
+│   └── ...
+├── ssl/                   # 【SSL 证书目录】
+│   ├── api.example.com/
+│   │   ├── key.pem
+│   │   └── fullchain.pem
+│   └── ...
+└── ...
 ```
 
 ### 日志目录
@@ -339,7 +288,6 @@ cat /etc/logrotate.d/nginx
 ```
 /etc/sysctl.d/99-vps-optimize.conf    # 内核参数
 /etc/security/limits.conf              # 文件描述符限制
-/etc/systemd/system/nginx.service      # Systemd 服务
 ```
 
 ---
@@ -359,35 +307,17 @@ uname -r
 
 # Ubuntu/Debian 升级内核
 apt update && apt install linux-generic-hwe-20.04
-
-# CentOS 7 升级内核
-rpm --import https://www.elrepo.org/RPM-GPG-KEY-elrepo.org
-yum install https://www.elrepo.org/elrepo-release-7.el7.elrepo.noarch.rpm
-yum --enablerepo=elrepo-kernel install kernel-ml
 reboot
 ```
 
-### 2. 编译失败
-
-**症状**: `configure: error: SSL modules require the OpenSSL library`
-
-**解决方案**:
-```bash
-# Ubuntu/Debian
-apt-get install -y libssl-dev libpcre3-dev zlib1g-dev
-
-# CentOS/RHEL
-yum install -y openssl-devel pcre-devel zlib-devel
-```
-
-### 3. 服务启动失败
+### 2. 服务启动失败
 
 **症状**: `Job for nginx.service failed`
 
 **排查步骤**:
 ```bash
 # 1. 测试配置语法
-/usr/local/nginx/sbin/nginx -t
+nginx -t
 
 # 2. 查看详细错误
 journalctl -xe -u nginx
@@ -400,19 +330,19 @@ netstat -tlnp | grep :443
 cat /var/log/nginx/error.log
 ```
 
-### 4. 如何添加新站点？
+### 3. 如何添加新站点？
 
-在 `/usr/local/nginx/conf/conf.d/` 创建新配置文件：
+在 `/etc/nginx/conf.d/` 创建新配置文件：
 
 ```bash
 # 示例: 添加 api.example.com
-cat > /usr/local/nginx/conf/conf.d/api.example.com.conf << 'EOF'
+cat > /etc/nginx/conf.d/api.example.com.conf << 'EOF'
 server {
     listen 443 ssl http2;
     server_name api.example.com;
 
-    ssl_certificate /usr/local/nginx/conf/ssl/api.example.com/fullchain.pem;
-    ssl_certificate_key /usr/local/nginx/conf/ssl/api.example.com/key.pem;
+    ssl_certificate /etc/nginx/ssl/api.example.com/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/api.example.com/key.pem;
 
     location / {
         proxy_pass http://127.0.0.1:3000;
@@ -423,7 +353,7 @@ server {
 EOF
 
 # 测试并重载
-/usr/local/nginx/sbin/nginx -t && systemctl reload nginx
+nginx -t && systemctl reload nginx
 ```
 
 ---
@@ -443,43 +373,18 @@ Nginx 部署完成后，可以继续部署以下服务：
 
 ---
 
-## 技术规格
-
-### 编译参数
-
-```bash
-./configure \
-  --prefix=/usr/local/nginx \
-  --user=www \
-  --group=www \
-  --with-http_ssl_module \
-  --with-http_v2_module \
-  --with-http_v3_module \
-  --with-http_realip_module \
-  --with-http_stub_status_module \
-  --with-http_gzip_static_module \
-  --with-http_gunzip_module \
-  --with-http_sub_module \
-  --with-http_flv_module \
-  --with-http_addition_module \
-  --with-http_mp4_module \
-  --with-http_dav_module \
-  --with-stream \
-  --with-stream_ssl_module \
-  --with-stream_ssl_preread_module \
-  --with-stream_realip_module \
-  --with-pcre \
-  --with-cc-opt='-O2 -g -pipe'
-```
-
-### 主配置文件核心参数
+## 主配置文件核心参数
 
 ```nginx
+user  www;
 worker_processes  auto;           # 自动匹配 CPU 核心
 worker_rlimit_nofile 65535;       # 文件描述符限制
-worker_connections  10240;        # 每进程最大连接数
-use epoll;                        # 高效事件模型
-multi_accept on;                  # 批量接受连接
+
+events {
+    worker_connections  10240;    # 每进程最大连接数
+    use epoll;                    # 高效事件模型
+    multi_accept on;              # 批量接受连接
+}
 ```
 
 ---
@@ -487,10 +392,11 @@ multi_accept on;                  # 批量接受连接
 ## 相关链接
 
 - **Nginx 官方文档**: https://nginx.org/en/docs/
+- **Nginx 主线仓库**: https://nginx.org/en/linux_packages.html#mainline
 - **HTTP/3 说明**: https://nginx.org/en/docs/http/ngx_http_v3_module.html
 - **BBR 算法**: https://github.com/google/bbr
 
 ---
 
-**文档维护**: Claude Code
-**最后更新**: 2026-01-16
+**文档维护**: AI Coding Assistant
+**最后更新**: 2026-05-27

--- a/0.nginx/install_nginx.sh
+++ b/0.nginx/install_nginx.sh
@@ -2,16 +2,15 @@
 
 ################################################################################
 #
-# Nginx 纯净安装与系统优化脚本
+# Nginx 安装与系统优化脚本 (v5.0)
 #
 # 功能说明：
 #   1. 系统内核优化：开启 BBR、优化 TCP 连接、提升文件描述符限制
-#   2. 编译安装 Nginx：仅包含必要模块 (SSL, V2, Stream, RealIP, StubStatus)
-#   3. 配置结构优化：构建模块化 conf.d 结构，方便后续扩展 API 或其他站点
+#   2. 通过 nginx.org 官方仓库安装最新主线版（支持 HTTP/3）
+#   3. 配置高并发优化
 #
 # 适用环境：
-#   - Ubuntu 20.04+ / Debian 11+ / CentOS 7+
-#   - 建议内存 512MB+
+#   - Ubuntu 20.04+ / Debian 11+
 #
 # 使用方法：
 #   chmod +x install_nginx.sh
@@ -21,9 +20,8 @@
 
 # ==================== 全局配置 ====================
 
-NGINX_VERSION="1.28.1"  # 使用最新稳定版（支持 HTTP/3）
-INSTALL_PATH="/usr/local/nginx"
-SRC_DIR="/usr/local/src"
+NGINX_CONF_DIR="/etc/nginx"
+NGINX_SSL_DIR="$NGINX_CONF_DIR/ssl"
 USER="www"
 GROUP="www"
 
@@ -40,27 +38,11 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-echo -e "${CYAN}>>> [1/4] 系统环境检查与优化...${NC}"
+echo -e "${CYAN}>>> [1/3] 系统环境检查与优化...${NC}"
 
-# 1. 自动挂载 Swap (如果内存 < 1GB)
-MEM_TOTAL=$(free -m | awk '/^Mem:/{print $2}')
-if [ "$MEM_TOTAL" -lt 1000 ]; then
-    if grep -q "/swapfile_install" /proc/swaps; then
-        echo -e "${GREEN}Swap 空间已存在，跳过。${NC}"
-    else
-        echo -e "${YELLOW}检测到低内存 ($MEM_TOTAL MB)，正在创建 1.5GB Swap...${NC}"
-        dd if=/dev/zero of=/swapfile_install bs=1M count=1536
-        chmod 600 /swapfile_install
-        mkswap /swapfile_install
-        swapon /swapfile_install
-        echo "/swapfile_install none swap sw 0 0" >> /etc/fstab
-        echo -e "${GREEN}Swap 创建完成。${NC}"
-    fi
-fi
-
-# 2. 内核参数优化 (开启 BBR + TCP 调优)
+# 1. 内核参数优化 (开启 BBR + TCP 调优)
 echo "正在优化 sysctl.conf..."
-cat > /etc/sysctl.d/99-vps-optimize.conf <<EOF
+cat > /etc/sysctl.d/99-vps-optimize.conf <<'EOF'
 # --- BBR 拥塞控制 ---
 net.core.default_qdisc = fq
 net.ipv4.tcp_congestion_control = bbr
@@ -91,7 +73,7 @@ else
     echo -e "${YELLOW}⚠ BBR 开启失败，请检查内核版本 (建议 >= 4.9)${NC}"
 fi
 
-# 3. 提升系统级文件描述符限制
+# 2. 提升系统级文件描述符限制
 if ! grep -q "* soft nofile 65535" /etc/security/limits.conf; then
     echo "* soft nofile 65535" >> /etc/security/limits.conf
     echo "* hard nofile 65535" >> /etc/security/limits.conf
@@ -99,78 +81,78 @@ if ! grep -q "* soft nofile 65535" /etc/security/limits.conf; then
     echo "root hard nofile 65535" >> /etc/security/limits.conf
 fi
 
-echo -e "${CYAN}>>> [2/4] 安装依赖库...${NC}"
-
-# 检测系统并安装依赖
-if [ -f /etc/debian_version ]; then
-    apt-get update -y
-    apt-get install -y build-essential libtool autoconf wget curl git \
-    libpcre3 libpcre3-dev zlib1g zlib1g-dev libssl-dev pkg-config
-elif [ -f /etc/redhat-release ]; then
-    yum install -y epel-release
-    yum groupinstall -y "Development Tools"
-    yum install -y wget curl pcre-devel zlib-devel openssl-devel
-fi
-
-# 创建用户
+# 3. 创建 nginx 运行用户
 id -u $USER &>/dev/null || useradd -s /sbin/nologin -M $USER
 
-echo -e "${CYAN}>>> [3/4] 编译安装 Nginx $NGINX_VERSION ...${NC}"
+echo -e "${CYAN}>>> [2/3] 安装 Nginx (nginx.org 官方主线包)...${NC}"
 
-mkdir -p $SRC_DIR
-cd $SRC_DIR
+# 检测系统并添加 nginx.org 官方仓库
+if [ -f /etc/debian_version ]; then
+    # 检测是否需要安装依赖
+    if ! command -v curl &> /dev/null; then
+        apt-get update -y -qq
+        apt-get install -y -qq curl gnupg2 ca-certificates lsb-release
+    fi
 
-# 下载源码
-if [ ! -f "nginx-$NGINX_VERSION.tar.gz" ]; then
-    wget -c "http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
+    # 添加 nginx.org GPG key
+    curl -fsSL https://nginx.org/keys/nginx_signing.key \
+        | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg
+
+    # 添加 mainline 仓库（支持 HTTP/3）
+    . /etc/os-release
+    if [ "$ID" = "debian" ] && [ -z "$VERSION_CODENAME" ]; then
+        VERSION_CODENAME=$(lsb_release -cs 2>/dev/null || echo "bookworm")
+    fi
+    echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+http://nginx.org/packages/mainline/${ID}/ ${VERSION_CODENAME} nginx" \
+        > /etc/apt/sources.list.d/nginx.list
+
+    # 优先使用 nginx.org 仓库
+    cat > /etc/apt/preferences.d/99nginx <<'EOF'
+Package: nginx*
+Pin: origin nginx.org
+Pin-Priority: 900
+EOF
+
+    apt-get update -y -qq
+    apt-get install -y nginx
+
+    echo -e "${GREEN}✓ Nginx 安装完成${NC}"
+
+elif [ -f /etc/redhat-release ]; then
+    echo -e "${RED}错误: CentOS / RHEL 不在本脚本的支持范围内。${NC}"
+    echo -e "${YELLOW}请使用 Ubuntu 20.04+ 或 Debian 11+。${NC}"
+    exit 1
+else
+    echo -e "${RED}错误: 不支持的操作系统。${NC}"
+    exit 1
 fi
-tar -zxvf nginx-$NGINX_VERSION.tar.gz
-cd nginx-$NGINX_VERSION
 
-# 编译配置 (增强版 - 包含 HTTP/3 支持)
-./configure \
-  --prefix=$INSTALL_PATH \
-  --user=$USER \
-  --group=$GROUP \
-  --with-http_ssl_module \
-  --with-http_v2_module \
-  --with-http_v3_module \
-  --with-http_realip_module \
-  --with-http_stub_status_module \
-  --with-http_gzip_static_module \
-  --with-http_gunzip_module \
-  --with-http_sub_module \
-  --with-http_flv_module \
-  --with-http_addition_module \
-  --with-http_mp4_module \
-  --with-http_dav_module \
-  --with-stream \
-  --with-stream_ssl_module \
-  --with-stream_ssl_preread_module \
-  --with-stream_realip_module \
-  --with-pcre \
-  --with-cc-opt='-O2 -g -pipe'
+# 验证 HTTP/3 模块
+if nginx -V 2>&1 | grep -q "http_v3_module"; then
+    echo -e "${GREEN}✓ HTTP/3 (QUIC) 模块已就绪${NC}"
+else
+    echo -e "${YELLOW}⚠ 当前 Nginx 未包含 HTTP/3 模块${NC}"
+fi
 
-# 编译与安装
-make -j$(nproc)
-make install
+echo -e "${CYAN}>>> [3/3] 配置 Nginx 高并发优化...${NC}"
 
-# 创建必要的目录结构
-mkdir -p $INSTALL_PATH/conf/conf.d
-mkdir -p $INSTALL_PATH/conf/ssl
+# 创建 SSL 证书存放目录（供后续服务使用）
+mkdir -p "$NGINX_SSL_DIR"
+chown -R $USER:$GROUP "$NGINX_SSL_DIR"
+
+# 创建日志目录并设权限
 mkdir -p /var/log/nginx
 chown -R $USER:$GROUP /var/log/nginx
 
-echo -e "${CYAN}>>> [4/4] 配置 Nginx 结构...${NC}"
-
-# 生成主配置文件 (优化高并发)
-cat > $INSTALL_PATH/conf/nginx.conf <<EOF
+# 生成 nginx.conf（高并发调优 + 模块化站点配置）
+cat > "$NGINX_CONF_DIR/nginx.conf" <<EOF
 user  $USER;
 worker_processes  auto;
 worker_rlimit_nofile 65535;
 
 error_log  /var/log/nginx/error.log warn;
-pid        $INSTALL_PATH/logs/nginx.pid;
+pid        /run/nginx.pid;
 
 events {
     worker_connections  10240;
@@ -179,17 +161,15 @@ events {
 }
 
 http {
-    include       mime.types;
+    include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # 日志格式 (包含真实 IP)
     log_format  main  '\$remote_addr - \$remote_user [\$time_local] "\$request" '
                       '\$status \$body_bytes_sent "\$http_referer" '
                       '"\$http_user_agent" "\$http_x_forwarded_for"';
 
     access_log  /var/log/nginx/access.log  main;
 
-    # 核心优化
     sendfile        on;
     tcp_nopush      on;
     tcp_nodelay     on;
@@ -197,50 +177,38 @@ http {
     types_hash_max_size 2048;
     server_tokens   off;
 
-    # Gzip 压缩
     gzip on;
     gzip_min_length 1k;
     gzip_comp_level 4;
     gzip_types text/plain text/css application/json application/javascript application/xml;
 
-    # 加载模块化配置 (关键点: 允许后续方便添加 API 站点)
-    include $INSTALL_PATH/conf/conf.d/*.conf;
+    # 加载模块化站点配置
+    include /etc/nginx/conf.d/*.conf;
 }
 EOF
 
-# 创建 Systemd 服务
-cat > /etc/systemd/system/nginx.service <<EOF
-[Unit]
-Description=The NGINX HTTP and reverse proxy server
-After=network-online.target nss-lookup.target
-Wants=network-online.target
+# 测试配置并启动
+nginx -t
+if [ $? -eq 0 ]; then
+    systemctl enable nginx
+    systemctl restart nginx
+    echo -e "${GREEN}✓ Nginx 配置测试通过，服务已启动${NC}"
+else
+    echo -e "${RED}✗ Nginx 配置测试失败，请检查${NC}"
+    exit 1
+fi
 
-[Service]
-Type=forking
-PIDFile=$INSTALL_PATH/logs/nginx.pid
-ExecStartPre=$INSTALL_PATH/sbin/nginx -t
-ExecStart=$INSTALL_PATH/sbin/nginx
-ExecReload=$INSTALL_PATH/sbin/nginx -s reload
-ExecStop=/bin/kill -s QUIT $MAINPID
-PrivateTmp=true
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-# 启动服务
-systemctl daemon-reload
-systemctl enable nginx
-systemctl restart nginx
-
-echo -e ""
+# 输出安装摘要
+NGINX_VERSION=$(nginx -v 2>&1 | grep -oP 'nginx/\K[0-9.]+')
+echo ""
 echo -e "${GREEN}==============================================${NC}"
-echo -e "${GREEN}   Nginx 安装与系统优化完成 (v4.0)   ${NC}"
+echo -e "${GREEN}   Nginx 安装与系统优化完成 (v5.0)   ${NC}"
 echo -e "${GREEN}==============================================${NC}"
-echo -e "Nginx 版本:   ${YELLOW}$NGINX_VERSION (支持 HTTP/3)${NC}"
-echo -e "Nginx 路径:   ${YELLOW}$INSTALL_PATH${NC}"
-echo -e "配置文件:     ${YELLOW}$INSTALL_PATH/conf/nginx.conf${NC}"
-echo -e "扩展配置:     ${YELLOW}$INSTALL_PATH/conf/conf.d/*.conf${NC}"
+echo -e "Nginx 版本:   ${YELLOW}$NGINX_VERSION${NC}"
+echo -e "安装来源:     ${YELLOW}nginx.org 官方主线仓库${NC}"
+echo -e "配置文件:     ${YELLOW}/etc/nginx/nginx.conf${NC}"
+echo -e "站点配置:     ${YELLOW}/etc/nginx/conf.d/*.conf${NC}"
+echo -e "SSL 证书:     ${YELLOW}/etc/nginx/ssl/${NC}"
 echo -e "优化状态:     ${GREEN}BBR 已开启, Limit 已提升${NC}"
-echo -e "HTTP/3 支持:  ${GREEN}✓ 已编译 (--with-http_v3_module)${NC}"
+echo -e "HTTP/3 支持:  ${GREEN}✓ (内置 --with-http_v3_module)${NC}"
 echo -e "${GREEN}==============================================${NC}"

--- a/1.v2ray/README.md
+++ b/1.v2ray/README.md
@@ -59,7 +59,7 @@ Nginx (TLS 终止)
 1. **Nginx 已安装**
    ```bash
    # 如未安装，先运行
-   cd "../0.nginx部署（1.28.1 HTTP3）"
+   cd "../0.nginx"
    ./install_nginx.sh
    ```
 
@@ -148,7 +148,7 @@ journalctl -u v2ray -f
 
 ```bash
 # 测试配置
-/usr/local/nginx/sbin/nginx -t
+nginx -t
 
 # 重载配置
 systemctl reload nginx
@@ -250,7 +250,7 @@ netstat -tlnp | grep :80
 systemctl status v2ray
 
 # 检查 Nginx 配置
-/usr/local/nginx/sbin/nginx -t
+nginx -t
 ```
 
 ---
@@ -260,8 +260,8 @@ systemctl status v2ray
 | 文件 | 路径 |
 |------|------|
 | V2Ray 配置 | `/usr/local/etc/v2ray/config.json` |
-| Nginx 站点配置 | `/usr/local/nginx/conf/conf.d/{domain}.conf` |
-| SSL 证书 | `/usr/local/nginx/conf/ssl/{domain}/` |
+| Nginx 站点配置 | `/etc/nginx/conf.d/{domain}.conf` |
+| SSL 证书 | `/etc/nginx/ssl/{domain}/` |
 | 伪装网站 | `/var/www/static/index.html` |
 | 连接信息 | `./v2ray_node_info.txt` |
 

--- a/1.v2ray/install_v2ray.sh
+++ b/1.v2ray/install_v2ray.sh
@@ -21,9 +21,8 @@
 # ==================== 全局配置 ====================
 
 V2RAY_PORT=10000
-NGINX_PATH="/usr/local/nginx"
-CONF_D="$NGINX_PATH/conf/conf.d"
-SSL_DIR="$NGINX_PATH/conf/ssl"
+CONF_D="/etc/nginx/conf.d"
+SSL_DIR="/etc/nginx/ssl"
 WEB_ROOT="/var/www/static"
 
 # 颜色定义
@@ -39,7 +38,7 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-if [ ! -d "$NGINX_PATH" ]; then
+if ! command -v nginx &> /dev/null; then
     echo -e "${RED}错误: 未检测到 Nginx，请先运行 install_nginx.sh${NC}"
     exit 1
 fi

--- a/2.cliproxyapi/apply_ssl.sh
+++ b/2.cliproxyapi/apply_ssl.sh
@@ -30,9 +30,8 @@
 
 # ==================== 全局配置 ====================
 
-NGINX_PATH="/usr/local/nginx"
-CONF_D="$NGINX_PATH/conf/conf.d"
-SSL_DIR="$NGINX_PATH/conf/ssl"
+CONF_D="/etc/nginx/conf.d"
+SSL_DIR="/etc/nginx/ssl"
 
 # 颜色定义
 RED='\033[0;31m'
@@ -114,7 +113,7 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-if [ ! -d "$NGINX_PATH" ]; then
+if ! command -v nginx &> /dev/null; then
     echo -e "${RED}错误: 未检测到 Nginx 安装。${NC}"
     exit 1
 fi
@@ -233,7 +232,7 @@ server {
 EOF
     TEMP_CONF=true
     mkdir -p /var/www/acme
-    $NGINX_PATH/sbin/nginx -t >/dev/null 2>&1 && systemctl reload nginx
+    nginx -t >/dev/null 2>&1 && systemctl reload nginx
 fi
 
 # 申请 ECC-256 证书
@@ -380,12 +379,12 @@ else
 fi
 
 # 测试并重载 Nginx
-if $NGINX_PATH/sbin/nginx -t >/dev/null 2>&1; then
+if nginx -t >/dev/null 2>&1; then
     systemctl reload nginx
     echo -e "${GREEN}✓ Nginx 配置测试通过并已重载${NC}"
 else
     echo -e "${RED}⚠ Nginx 配置测试失败，请检查配置${NC}"
-    $NGINX_PATH/sbin/nginx -t
+    nginx -t
 fi
 
 # ==================== 输出结果 ====================

--- a/2.cliproxyapi/install_cliproxyapi_v2.sh
+++ b/2.cliproxyapi/install_cliproxyapi_v2.sh
@@ -32,9 +32,8 @@
 # ==================== 全局配置 ====================
 
 CLIPROXY_PORT=8317
-NGINX_PATH="/usr/local/nginx"
-CONF_D="$NGINX_PATH/conf/conf.d"
-SSL_DIR="$NGINX_PATH/conf/ssl"
+CONF_D="/etc/nginx/conf.d"
+SSL_DIR="/etc/nginx/ssl"
 
 INSTALL_DIR="/opt/cliproxyapi"
 CONFIG_DIR="/etc/cliproxyapi"
@@ -81,7 +80,7 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-if [ ! -d "$NGINX_PATH" ]; then
+if ! command -v nginx &> /dev/null; then
     log_error "未检测到 Nginx，请先运行 install_nginx.sh"
     exit 1
 fi
@@ -603,7 +602,7 @@ if [ "$IS_UPGRADE" = false ] && [ -n "$DOMAIN" ]; then
 
     # 检测 HTTP/3 支持
     NGINX_SUPPORTS_HTTP3=false
-    if $NGINX_PATH/sbin/nginx -V 2>&1 | grep -q "http_v3_module"; then
+    if nginx -V 2>&1 | grep -q "http_v3_module"; then
         NGINX_SUPPORTS_HTTP3=true
     fi
 
@@ -946,12 +945,12 @@ EOF_NGINX_NO_H3
     log_success "Nginx 配置已生成"
 
     # 测试并重载
-    if $NGINX_PATH/sbin/nginx -t >/dev/null 2>&1; then
+    if nginx -t >/dev/null 2>&1; then
         systemctl reload nginx
         log_success "Nginx 已重载"
     else
         log_error "Nginx 配置测试失败"
-        $NGINX_PATH/sbin/nginx -t
+        nginx -t
     fi
 fi
 

--- a/2.cliproxyapi/uninstall_cliproxyapi.sh
+++ b/2.cliproxyapi/uninstall_cliproxyapi.sh
@@ -123,7 +123,7 @@ echo -e "${GREEN}✓ Nginx 日志已清理${NC}"
 echo -e "${CYAN}>>> [6/6] 删除 Nginx 配置...${NC}"
 
 # 查找并删除 CliproxyAPI 相关的 Nginx 配置
-NGINX_CONF_DIR="/usr/local/nginx/conf/conf.d"
+NGINX_CONF_DIR="/etc/nginx/conf.d"
 CLIPROXY_CONFIGS=$(find "$NGINX_CONF_DIR" -name "*.conf" -exec grep -l "cliproxyapi\|8317" {} \; 2>/dev/null)
 
 if [ -n "$CLIPROXY_CONFIGS" ]; then
@@ -140,21 +140,21 @@ if [ -n "$CLIPROXY_CONFIGS" ]; then
         echo -e "${GREEN}✓ 已删除: $conf${NC}"
 
         # 询问是否删除 SSL 证书
-        if [ -n "$DOMAIN" ] && [ -d "/usr/local/nginx/conf/ssl/$DOMAIN" ]; then
+        if [ -n "$DOMAIN" ] && [ -d "/etc/nginx/ssl/$DOMAIN" ]; then
             echo ""
             read -p "是否删除 $DOMAIN 的 SSL 证书? (y/N): " -n 1 -r
             echo
             if [[ $REPLY =~ ^[Yy]$ ]]; then
-                rm -rf "/usr/local/nginx/conf/ssl/$DOMAIN"
-                echo -e "${GREEN}✓ 已删除 SSL 证书: /usr/local/nginx/conf/ssl/$DOMAIN${NC}"
+                rm -rf "/etc/nginx/ssl/$DOMAIN"
+                echo -e "${GREEN}✓ 已删除 SSL 证书: /etc/nginx/ssl/$DOMAIN${NC}"
             else
-                echo -e "${YELLOW}✓ 已保留 SSL 证书: /usr/local/nginx/conf/ssl/$DOMAIN${NC}"
+                echo -e "${YELLOW}✓ 已保留 SSL 证书: /etc/nginx/ssl/$DOMAIN${NC}"
             fi
         fi
     done
 
     # 测试并重载 Nginx
-    if /usr/local/nginx/sbin/nginx -t >/dev/null 2>&1; then
+    if nginx -t >/dev/null 2>&1; then
         systemctl reload nginx
         echo -e "${GREEN}✓ Nginx 已重载${NC}"
     else

--- a/3.new-api/install_newapi_docker.sh
+++ b/3.new-api/install_newapi_docker.sh
@@ -34,9 +34,8 @@ NEWAPI_PORT=3000
 POSTGRES_PORT=5432
 REDIS_PORT=6379
 
-NGINX_PATH="/usr/local/nginx"
-CONF_D="$NGINX_PATH/conf/conf.d"
-SSL_DIR="$NGINX_PATH/conf/ssl"
+CONF_D="/etc/nginx/conf.d"
+SSL_DIR="/etc/nginx/ssl"
 
 DOCKER_ROOT="/opt/docker-services"
 SERVICE_DIR="$DOCKER_ROOT/new-api"
@@ -145,7 +144,7 @@ else
 fi
 
 # 检查 Nginx
-if [ ! -d "$NGINX_PATH" ]; then
+if ! command -v nginx &> /dev/null; then
     log_error "未检测到 Nginx，请先运行 install_nginx.sh"
     exit 1
 fi
@@ -659,7 +658,7 @@ log_step "[7/8] 配置 Nginx 反向代理..."
 
 # 检测 HTTP/3 支持
 NGINX_SUPPORTS_HTTP3=false
-if $NGINX_PATH/sbin/nginx -V 2>&1 | grep -q "http_v3_module"; then
+if nginx -V 2>&1 | grep -q "http_v3_module"; then
     NGINX_SUPPORTS_HTTP3=true
     log_info "检测到 HTTP/3 支持"
 fi
@@ -858,12 +857,12 @@ sed -i "s|NEWAPI_PORT_PLACEHOLDER|$NEWAPI_PORT|g" "$CONF_D/${DOMAIN}.conf"
 log_success "Nginx 配置已生成"
 
 # 测试并重载 Nginx
-if $NGINX_PATH/sbin/nginx -t >/dev/null 2>&1; then
+if nginx -t >/dev/null 2>&1; then
     systemctl reload nginx
     log_success "Nginx 已重载"
 else
     log_error "Nginx 配置测试失败"
-    $NGINX_PATH/sbin/nginx -t
+    nginx -t
 fi
 
 # ==================== 生成配置信息文件 ====================
@@ -957,7 +956,7 @@ cat >> "$INFO_FILE" <<EOF
 
 [Nginx 配置]
 配置文件:  $CONF_D/${DOMAIN}.conf
-测试配置:  $NGINX_PATH/sbin/nginx -t
+测试配置:  nginx -t
 重载配置:  systemctl reload nginx
 
 [Docker 网络]

--- a/3.new-api/uninstall_newapi_docker.sh
+++ b/3.new-api/uninstall_newapi_docker.sh
@@ -120,7 +120,7 @@ log_step "[1/7] 检测当前服务状态..."
 cd "$SERVICE_DIR"
 
 # 获取域名（从 Nginx 配置）
-DOMAIN=$(find /usr/local/nginx/conf/conf.d/ -name "*newapi*.conf" 2>/dev/null | head -1 | xargs -I {} basename {} .conf 2>/dev/null)
+DOMAIN=$(find /etc/nginx/conf.d/ -name "*newapi*.conf" 2>/dev/null | head -1 | xargs -I {} basename {} .conf 2>/dev/null)
 
 if [ -z "$DOMAIN" ]; then
     DOMAIN="unknown"
@@ -243,7 +243,7 @@ echo ""
 log_step "[5/7] 删除 Nginx 配置..."
 
 # 查找 Nginx 配置文件
-NGINX_CONF=$(find /usr/local/nginx/conf/conf.d/ -name "*newapi*.conf" 2>/dev/null | head -1)
+NGINX_CONF=$(find /etc/nginx/conf.d/ -name "*newapi*.conf" 2>/dev/null | head -1)
 
 if [ -n "$NGINX_CONF" ] && [ -f "$NGINX_CONF" ]; then
     log_info "检测到 Nginx 配置: $NGINX_CONF"
@@ -254,8 +254,8 @@ if [ -n "$NGINX_CONF" ] && [ -f "$NGINX_CONF" ]; then
     if systemctl is-active --quiet nginx 2>/dev/null; then
         systemctl reload nginx
         log_success "Nginx 已重载"
-    elif [ -f /usr/local/nginx/sbin/nginx ]; then
-        /usr/local/nginx/sbin/nginx -s reload 2>/dev/null
+    elif command -v nginx &> /dev/null; then
+        systemctl reload nginx 2>/dev/null
         log_success "Nginx 已重载"
     fi
 else
@@ -269,7 +269,7 @@ echo ""
 log_step "[6/7] 删除 SSL 证书..."
 
 if [ "$DOMAIN" != "unknown" ]; then
-    SSL_DIR="/usr/local/nginx/conf/ssl/$DOMAIN"
+    SSL_DIR="/etc/nginx/ssl/$DOMAIN"
 
     if [ -d "$SSL_DIR" ]; then
         read -p "是否删除 SSL 证书？($DOMAIN) (y/N): " DELETE_SSL

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ vps_deployment_ai_tools/
 
 ### 0.nginx - Nginx 基础设施【必选】
 
-> **部署方式**: 源码编译
+> **部署方式**: 官方仓库安装
 
-- Nginx 1.28.1 源码编译，支持 HTTP/3 (QUIC)
+- Nginx 来自 nginx.org 官方主线仓库，支持 HTTP/3 (QUIC)
 - 自动开启 TCP BBR，优化系统内核参数
 - 构建模块化配置结构 (conf.d/)
 - 编译 Stream 模块，支持四层代理
@@ -234,7 +234,7 @@ cd 8.service-monitor && ./install_monitor.sh
 
 > **⚠️ 重要**：同一台服务器部署多个服务时，必须为每个服务使用不同的子域名。
 >
-> Nginx 配置文件路径为 `/usr/local/nginx/conf/conf.d/{域名}.conf`，相同域名会导致配置覆盖。
+> Nginx 配置文件路径为 `/etc/nginx/conf.d/{域名}.conf`，相同域名会导致配置覆盖。
 >
 > 正确示例：`proxy.example.com`、`api.example.com`、`newapi.example.com`
 
@@ -246,7 +246,7 @@ cd 8.service-monitor && ./install_monitor.sh
 
 ```bash
 systemctl status nginx
-/usr/local/nginx/sbin/nginx -t
+nginx -t
 systemctl reload nginx
 tail -f /var/log/nginx/error.log
 ```

--- a/deploy_cluster.sh
+++ b/deploy_cluster.sh
@@ -105,18 +105,17 @@ check_root() {
 # ==================== 服务安装函数 ====================
 
 install_nginx() {
-    print_section "安装 Nginx 1.28.1 (HTTP/3)"
+    print_section "安装 Nginx (HTTP/3)"
 
     echo -e "${WHITE}功能说明:${NC}"
-    echo "  • Nginx 1.28.1 源码编译安装，支持最新的 HTTP/3 (QUIC) 协议"
+    echo "  • Nginx 来自 nginx.org 官方主线仓库，支持最新的 HTTP/3 (QUIC) 协议"
     echo "  • 自动开启 TCP BBR 拥塞控制算法，提升网络性能 20-30%"
     echo "  • 优化系统内核参数，提升文件描述符限制"
     echo "  • 构建模块化配置结构 (conf.d/)，方便后续服务扩展"
-    echo "  • 编译 Stream 模块，支持四层 TCP/UDP 负载均衡"
     echo ""
     echo -e "${YELLOW}⚠️  这是所有后续服务的基础组件，必须安装！${NC}"
     echo ""
-    echo -e "${DIM}预计安装时间: 5-10 分钟（取决于服务器性能）${NC}"
+    echo -e "${DIM}预计安装时间: 约 30 秒（apt 安装，无需编译）${NC}"
     echo ""
 
     if confirm "是否开始安装 Nginx？" "y"; then
@@ -127,7 +126,7 @@ install_nginx() {
 
         if [ $? -eq 0 ]; then
             NGINX_INSTALLED=true
-            INSTALLED_SERVICES+=("Nginx 1.28.1")
+            INSTALLED_SERVICES+=("Nginx (HTTP/3)")
             echo ""
             echo -e "${GREEN}✓ Nginx 安装成功！${NC}"
         else
@@ -365,7 +364,7 @@ print_summary() {
     echo ""
     echo "  Nginx:"
     echo "    systemctl status nginx"
-    echo "    /usr/local/nginx/sbin/nginx -t"
+    echo "    nginx -t"
     echo "    systemctl reload nginx"
     echo ""
 
@@ -401,7 +400,7 @@ main() {
     echo "本工具将引导您按顺序部署 VPS 集群的各个组件。"
     echo ""
     echo -e "${CYAN}可用组件:${NC}"
-    echo "  0. Nginx 1.28.1 (HTTP/3)  - 基础设施【必选】"
+    echo "  0. Nginx (HTTP/3)          - 基础设施【必选】"
     echo "  01. Docker 容器环境        - 容器服务前置依赖【推荐】"
     echo "  1. V2Ray 代理节点          - 科学上网"
     echo "  2. CliproxyAPI            - 轻量 AI API 转发"

--- a/docs/cloudflare-dns-guide.md
+++ b/docs/cloudflare-dns-guide.md
@@ -108,7 +108,7 @@ dig +short your-domain.com
 
 1. 在 Cloudflare **SSL/TLS → Origin Server** 中创建证书
 2. 下载证书和私钥
-3. 放到 `/usr/local/nginx/conf/ssl/{domain}/` 目录
+3. 放到 `/etc/nginx/ssl/{domain}/` 目录
 4. 将 Cloudflare SSL 模式设为 **Full (strict)**
 
 ### 4. 多个子域名可以用通配符吗？


### PR DESCRIPTION
- 全面移除源码编译流程（build-essential、./configure、make）
- 改用 nginx.org 官方 apt 仓库安装主线版（内置 HTTP/3）
- 移除静默 Swap 创建逻辑
- 统一所有路径：/usr/local/nginx → /etc/nginx
- 统一 nginx 命令调用：直接使用 PATH 中的 nginx
- 统一 nginx 检测方式：command -v nginx
- 移除无用模块（FLV、MP4、DAV）
- 不再支持 CentOS 7
- 修复 00-high-performance.conf 中 events 块放 http 上下文的语法错误
- 安装耗时从 5-10 分钟降至 ~30 秒

涉及 12 个文件：1 重写 + 5 脚本路径替换 + 4 文档更新 + 2 卸载脚本路径替换